### PR TITLE
optional hiding and refresh on resize

### DIFF
--- a/ncmpcpp_cover_art.sh
+++ b/ncmpcpp_cover_art.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Cover art script for ncmpcpp-ueberzug
 
-# SETTINGS 
+# SETTINGS
 music_library="$HOME/music"
 fallback_image="$HOME/.ncmpcpp/ncmpcpp-ueberzug/img/fallback.png"
 padding_top=3
@@ -25,9 +25,7 @@ font_width=
 
 main() {
     if [ "$hide_while_stopped" = "true" ] && [ "$MPD_PLAYER_STATE" = "stop" ]; then
-        send_to_ueberzug \
-        action "remove" \
-        identifier "mpd_cover"
+        clear_cover_image
         return
     elif [ "$hide_while_stopped" = "false" ] && [ "$MPD_PLAYER_STATE" = "stop" ]; then
         return
@@ -96,6 +94,13 @@ display_cover_image() {
         scaler "forced_cover" \
         scaling_position_x "0.5"
 }
+
+clear_cover_image() {
+    send_to_ueberzug \
+    action "remove" \
+    identifier "mpd_cover"
+}
+
 
 
 # ==== Helper functions =========================================================

--- a/ncmpcpp_cover_art.sh
+++ b/ncmpcpp_cover_art.sh
@@ -18,6 +18,7 @@ left_aligned="false"
 padding_left=
 
 # Only set this if the geometries are wrong or ncmpcpp shouts at you to do it.
+# Visually select/highlight a character on your terminal, zoom in an image 
 # editor and count how many pixels a character's width and height are.
 font_height=
 font_width=
@@ -195,12 +196,14 @@ guess_terminal_pixelsize() {
 
     python <<END
 import sys, struct, fcntl, termios
+
 def get_geometry():
     fd_pty = sys.stdout.fileno()
     farg = struct.pack("HHHH", 0, 0, 0, 0)
     fretint = fcntl.ioctl(fd_pty, termios.TIOCGWINSZ, farg)
     rows, cols, xpixels, ypixels = struct.unpack("HHHH", fretint)
     return "{} {}".format(xpixels, ypixels)
+
 output = get_geometry()
 f = open("/tmp/ncmpcpp_geometry.txt", "w")
 f.write(output)


### PR DESCRIPTION
Requires 'execute_on_song_change' to be changed to '**execute_on_player_state_change**' when loading the script within ncmpcpp's main configuration. 

Benefits:
- New option that hides album art upon stopping playback, which defaults to false. 
- Album art now re-situates upon resizing terminal (tested with kitty) without a running loop, as resizing also triggers the state_change event.